### PR TITLE
Fix HTML script bugs and add wrapper functions

### DIFF
--- a/sheetService.gs
+++ b/sheetService.gs
@@ -147,3 +147,10 @@ var SheetService = {
     return { daily: daily, weekly: weekly };
   }
 };
+function saveMealEntry(data) {
+  SheetService.saveMealEntry(data);
+}
+
+function getStatsData() {
+  return SheetService.getStatsData();
+}

--- a/statsModalTemplate.html
+++ b/statsModalTemplate.html
@@ -1,5 +1,4 @@
 <!-- This file includes embedded JS/CSS due to project type rules -->
-<script>
 <html>
   <head>
     <base target="_top">
@@ -122,7 +121,7 @@
           google.script.run
             .withFailureHandler(displayError)
             .withSuccessHandler(renderCharts)
-            .sheetService.getStatsData();
+            .getStatsData();
         });
       });
 
@@ -137,4 +136,3 @@
     </script>
   </body>
 </html>
-</script>


### PR DESCRIPTION
## Summary
- remove extraneous `<script>` wrapper from the statistics modal template
- call a global `getStatsData` function in the modal instead of object method
- expose new global `saveMealEntry` and `getStatsData` functions for `google.script.run`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b7757cf288327a685bc7334ce3b75