### PR TITLE
Add missing include function

### DIFF
--- a/include.gs
+++ b/include.gs
@@ -1,0 +1,7 @@
+function include(filename) {
+  if (typeof filename !== 'string' || filename.trim() === '') {
+    throw new Error('Filename must be a non-empty string');
+  }
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+


### PR DESCRIPTION
## Summary
- add utility `include()` to render HTML partials used in templates

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684b7afb296483279f3bc5bc5914bc80