### PR TITLE
Fix meal type handling and sidebar styles

### DIFF
--- a/sheetService.gs
+++ b/sheetService.gs
@@ -53,9 +53,10 @@ var SheetService = {
     if (!description) {
       throw new Error('Invalid input: description is required');
     }
-    var type = String(data.type || '').toLowerCase();
-    var allowedTypes = config.ui.mealTypes || ['breakfast','snack','lunch','dinner'];
-    if (allowedTypes.indexOf(type) === -1) {
+      var type = String(data.type || '').toLowerCase();
+      var allowedTypes = (config.MEAL_TYPES || ['Breakfast','Lunch','Dinner','Snack'])
+        .map(function(t) { return String(t).toLowerCase(); });
+      if (allowedTypes.indexOf(type) === -1) {
       throw new Error('Invalid input: type must be one of ' + allowedTypes.join(', '));
     }
     var water = Number(data.water);
@@ -153,4 +154,8 @@ function saveMealEntry(data) {
 
 function getStatsData() {
   return SheetService.getStatsData();
+}
+
+function getMealTypes() {
+  return getConfig().MEAL_TYPES || [];
 }

--- a/sidebarTemplate.html
+++ b/sidebarTemplate.html
@@ -30,9 +30,9 @@
           <input type="number" id="weight" name="weight" min="0" step="0.1" />
         </div>
         <div class="button-group">
-          <button type="submit" id="saveBtn" class="btn primary">Save</button>
-          <button type="button" id="resetBtn" class="btn secondary">Reset</button>
-          <button type="button" id="statsBtn" class="btn link">View Statistics</button>
+          <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+          <button type="button" id="resetBtn" class="btn btn-secondary">Reset</button>
+          <button type="button" id="statsBtn" class="btn btn-secondary">View Statistics</button>
         </div>
         <div class="spinner" id="spinner" hidden></div>
       </form>
@@ -40,14 +40,21 @@
     <script>
       // Populate meal type dropdown
       function populateMealTypes() {
-        var types = ['Breakfast','Snack','Lunch','Dinner'];
         var select = document.getElementById('mealType');
-        types.forEach(function(t) {
-          var opt = document.createElement('option');
-          opt.value = t.toLowerCase();
-          opt.textContent = t;
-          select.appendChild(opt);
-        });
+        google.script.run
+          .withFailureHandler(function(err) {
+            console.log('Failed to load meal types:', err);
+          })
+          .withSuccessHandler(function(types) {
+            if (!Array.isArray(types)) return;
+            types.forEach(function(t) {
+              var opt = document.createElement('option');
+              opt.value = String(t).toLowerCase();
+              opt.textContent = t;
+              select.appendChild(opt);
+            });
+          })
+          .getMealTypes();
       }
 
       function showLoading() {


### PR DESCRIPTION
## Summary
- ensure allowed meal types come from config
- expose a new server function for meal types
- load meal types dynamically in sidebar
- use btn-primary and btn-secondary styles

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b7bee5b3c832796f56b9cbeb42799